### PR TITLE
Add integer sorting and swapping functions, refactor operation functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,13 +32,14 @@ SRC			= $(addprefix $(PATH_SRC), ft_isalpha.c ft_isdigit.c ft_isalnum.c \
 				ft_itoa_hex.c ft_check_string.c ft_printf.c ft_manage_params.c \
 				ft_write_params.c ft_apply_flags.c ft_for_each.c \
 				ft_arr_for_each.c ft_arr_split.c ft_arr_len.c ft_ternary.c \
-				ft_handle_error.c ft_putstr_color_fd.c ft_atol.c ft_operate.c)
+				ft_handle_error.c ft_putstr_color_fd.c ft_atol.c ft_operate.c \
+				ft_sort_int_arr.c ft_swap.c)
 
 HEADER = includes/
 
 AR = ar -rcs
 
-FLAGS = -Wall -Wextra -Wunreachable-code -Ofast -g3 -O3
+FLAGS = -Wall -Wextra -Wunreachable-code -g3
 
 OBJS = $(patsubst $(PATH_SRC)%.c, $(PATH_OBJ)%.o, $(SRC))
 

--- a/includes/libft.h
+++ b/includes/libft.h
@@ -224,7 +224,9 @@ void				ft_putstr_color_fd(char *color, char *s, int fd);
 
 //Push Swap
 long				ft_atol(const char *nptr);
-long long			ft_operate(long long nbr1, long long nbr2, char operate);
+int					ft_operate(int nbr1, int nbr2, char operate);
+void				ft_sort_int_arr(int *arr, size_t size);
+void				ft_swap(int *nbr1, int *nbr2);
 
 # ifndef MIN
 #  define MIN 0b0

--- a/sources/ft_arr_for_each.c
+++ b/sources/ft_arr_for_each.c
@@ -12,7 +12,7 @@
 
 #include "../includes/libft.h"
 
-void	ft_array_for_each(void **array, void (*array_f)(void *),
+void	ft_arr_for_each(void **array, void (*array_f)(void *),
 	void (*index_f)(void *))
 {
 	while (*array)

--- a/sources/ft_sort_int_arr.c
+++ b/sources/ft_sort_int_arr.c
@@ -1,7 +1,7 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_operate.c                                       :+:      :+:    :+:   */
+/*   ft_sort_int_arr.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: jovicto2 <jovicto2@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
@@ -12,15 +12,21 @@
 
 #include "../includes/libft.h"
 
-int	ft_operate(int nbr1, int nbr2, char operator)
+void	ft_sort_int_arr(int *arr, size_t size)
 {
-	if (operator == MIN)
+	size_t	first_index;
+	size_t	second_index;
+
+	first_index = 0;
+	while (first_index < size)
 	{
-		if (nbr1 <= nbr2)
-			return (nbr1);
-		return (nbr2);
+		second_index = first_index + 1;
+		while (second_index < size)
+		{
+			if (arr[first_index] > arr[second_index])
+				ft_swap((arr + first_index), (arr + second_index));
+			second_index++;
+		}
+		first_index++;
 	}
-	if (nbr1 >= nbr2)
-		return (nbr1);
-	return (nbr2);
 }

--- a/sources/ft_swap.c
+++ b/sources/ft_swap.c
@@ -1,7 +1,7 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_operate.c                                       :+:      :+:    :+:   */
+/*   ft_swap.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: jovicto2 <jovicto2@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
@@ -12,15 +12,9 @@
 
 #include "../includes/libft.h"
 
-int	ft_operate(int nbr1, int nbr2, char operator)
+void	ft_swap(int *nbr1, int *nbr2)
 {
-	if (operator == MIN)
-	{
-		if (nbr1 <= nbr2)
-			return (nbr1);
-		return (nbr2);
-	}
-	if (nbr1 >= nbr2)
-		return (nbr1);
-	return (nbr2);
+	*nbr1 ^= *nbr2;
+	*nbr2 ^= *nbr1;
+	*nbr1 ^= *nbr2;
 }


### PR DESCRIPTION
This commit adds two new functions, `ft_sort_int_arr` for sorting integer arrays and `ft_swap` for swapping two integers. Meanwhile, it also refactors the `ft_operate` function to use integers instead of long long integers. Additionally, some other functions, like `ft_arr_for_each` are renamed for consistency and readability.