### PR TITLE
Update compiler flags in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ HEADER = includes/
 
 AR = ar -rcs
 
-FLAGS = -Wall -Wextra -Wunreachable-code -g3
+FLAGS = -Wall -Wextra -Werror -Wunreachable-code -Ofast -g3 -O3
 
 OBJS = $(patsubst $(PATH_SRC)%.c, $(PATH_OBJ)%.o, $(SRC))
 


### PR DESCRIPTION
Compiler flags in the Makefile of the libft library have been updated for increased optimization and stricter error detection. `-Ofast` and `-O3` flags were added for faster execution speed, and `-Werror` was introduced for treating warnings as errors. This will improve code quality by ensuring high coding standards and optimization.